### PR TITLE
handle errors from the classification api

### DIFF
--- a/Replay/UI/AvalonSyntaxHighlightTransformer.cs
+++ b/Replay/UI/AvalonSyntaxHighlightTransformer.cs
@@ -27,7 +27,7 @@ namespace Replay.UI
             if (line.Length == 0) return;
 
             string text = context.CurrentContext.Document.GetText(line);
-            var spans = await replServices.HighlightAsync(lineNumber, text);
+            IReadOnlyCollection<ColorSpan> spans = await HighlightAsync(text);
 
             int offset = line.Offset;
             foreach (var span in spans)
@@ -36,6 +36,19 @@ namespace Replay.UI
                 {
                     part.TextRunProperties.SetForegroundBrush(new SolidColorBrush(span.Color));
                 });
+            }
+        }
+
+        private async Task<IReadOnlyCollection<ColorSpan>> HighlightAsync(string text)
+        {
+            try
+            {
+                return await replServices.HighlightAsync(lineNumber, text);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(ex.Message);
+                return Array.Empty<ColorSpan>();
             }
         }
     }


### PR DESCRIPTION
we can sometimes get errors deep from the roslyn classification api, like this:

```
Exception Info: System.InvalidOperationException: Sequence contains no elements
   at System.Linq.ThrowHelper.ThrowNoElementsException()
   at System.Linq.Enumerable.Single[TSource](IEnumerable`1 source)
   at Microsoft.CodeAnalysis.CSharp.Imports.ExpandPreviousSubmissionNamespace(NamespaceSymbol originalNamespace, NamespaceSymbol expandedGlobalNamespace)
   at Microsoft.CodeAnalysis.CSharp.Imports.ExpandPreviousSubmissionImports(Imports previousSubmissionImports, CSharpCompilation newSubmission)
   at Microsoft.CodeAnalysis.CSharp.Binder.LookupMembersInSubmissions(LookupResult result, TypeSymbol submissionClass, String name, Int32 arity, ConsList`1 basesBeingResolved, LookupOptions options, Binder originalBinder, Boolean diagnose, HashSet`1& useSiteDiagnostics)
   at Microsoft.CodeAnalysis.CSharp.InContainerBinder.LookupSymbolsInSingleBinder(LookupResult result, String name, Int32 arity, ConsList`1 basesBeingResolved, LookupOptions options, Binder originalBinder, Boolean diagnose, HashSet`1& useSiteDiagnostics)
   at Microsoft.CodeAnalysis.CSharp.Binder.LookupSymbolsInternal(LookupResult result, String name, Int32 arity, ConsList`1 basesBeingResolved, LookupOptions options, Boolean diagnose, HashSet`1& useSiteDiagnostics)
   at Microsoft.CodeAnalysis.CSharp.Binder.BindTypeOrAliasOrKeyword(SyntaxToken identifier, SyntaxNode syntax, DiagnosticBag diagnostics, Boolean& isKeyword)
   at Microsoft.CodeAnalysis.CSharp.Binder.BindTypeOrAliasOrVarKeyword(TypeSyntax syntax, DiagnosticBag diagnostics, Boolean& isVar)
   at Microsoft.CodeAnalysis.CSharp.Binder.BindTypeOrVarKeyword(TypeSyntax syntax, DiagnosticBag diagnostics, Boolean& isVar)
   at Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberFieldSymbolFromDeclarator.GetFieldType(ConsList`1 fieldsBeingBound)
   at Microsoft.CodeAnalysis.CSharp.Binder.IsInvocableMember(Symbol symbol)
   at Microsoft.CodeAnalysis.CSharp.Binder.IsNonInvocableMember(Symbol symbol)
   at Microsoft.CodeAnalysis.CSharp.Binder.CheckViability(Symbol symbol, Int32 arity, LookupOptions options, TypeSymbol accessThroughType, Boolean diagnose, HashSet`1& useSiteDiagnostics, ConsList`1 basesBeingResolved)
   at Microsoft.CodeAnalysis.CSharp.Binder.LookupMembersInSubmissions(LookupResult result, TypeSymbol submissionClass, String name, Int32 arity, ConsList`1 basesBeingResolved, LookupOptions options, Binder originalBinder, Boolean diagnose, HashSet`1& useSiteDiagnostics)
   at Microsoft.CodeAnalysis.CSharp.InContainerBinder.LookupSymbolsInSingleBinder(LookupResult result, String name, Int32 arity, ConsList`1 basesBeingResolved, LookupOptions options, Binder originalBinder, Boolean diagnose, HashSet`1& useSiteDiagnostics)
   at Microsoft.CodeAnalysis.CSharp.Binder.LookupSymbolsInternal(LookupResult result, String name, Int32 arity, ConsList`1 basesBeingResolved, LookupOptions options, Boolean diagnose, HashSet`1& useSiteDiagnostics)
   at Microsoft.CodeAnalysis.CSharp.Binder.LookupSymbolsWithFallback(LookupResult result, String name, Int32 arity, HashSet`1& useSiteDiagnostics, ConsList`1 basesBeingResolved, LookupOptions options)
   at Microsoft.CodeAnalysis.CSharp.Binder.BindIdentifier(SimpleNameSyntax node, Boolean invoked, Boolean indexed, DiagnosticBag diagnostics)
   at Microsoft.CodeAnalysis.CSharp.Binder.BindInvocationExpression(InvocationExpressionSyntax node, DiagnosticBag diagnostics)
   at Microsoft.CodeAnalysis.CSharp.Binder.BindExpressionInternal(ExpressionSyntax node, DiagnosticBag diagnostics, Boolean invoked, Boolean indexed)
   at Microsoft.CodeAnalysis.CSharp.Binder.BindExpression(ExpressionSyntax node, DiagnosticBag diagnostics, Boolean invoked, Boolean indexed)
   at Microsoft.CodeAnalysis.CSharp.Binder.BindExpressionStatement(CSharpSyntaxNode node, ExpressionSyntax syntax, Boolean allowsAnyExpression, DiagnosticBag diagnostics)
   at Microsoft.CodeAnalysis.CSharp.Binder.BindExpressionStatement(ExpressionStatementSyntax node, DiagnosticBag diagnostics)
   at Microsoft.CodeAnalysis.CSharp.Binder.BindStatement(StatementSyntax node, DiagnosticBag diagnostics)
   at Microsoft.CodeAnalysis.CSharp.MemberSemanticModel.IncrementalBinder.BindStatement(StatementSyntax node, DiagnosticBag diagnostics)
   at Microsoft.CodeAnalysis.CSharp.MemberSemanticModel.GetBoundNodes(CSharpSyntaxNode node)
   at Microsoft.CodeAnalysis.CSharp.MemberSemanticModel.GetLowerBoundNode(CSharpSyntaxNode node)
   at Microsoft.CodeAnalysis.CSharp.MemberSemanticModel.GetBoundNodes(CSharpSyntaxNode node, CSharpSyntaxNode& bindableNode, BoundNode& lowestBoundNode, BoundNode& highestBoundNode, BoundNode& boundParent)
   at Microsoft.CodeAnalysis.CSharp.MemberSemanticModel.GetSymbolInfoWorker(CSharpSyntaxNode node, SymbolInfoOptions options, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.CSharp.SyntaxTreeSemanticModel.GetSymbolInfoWorker(CSharpSyntaxNode node, SymbolInfoOptions options, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.CSharp.CSharpSemanticModel.GetSymbolInfo(ExpressionSyntax expression, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.CSharp.CSharpExtensions.GetSymbolInfo(SemanticModel semanticModel, ExpressionSyntax expression, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.CSharp.Classification.Classifiers.NameSyntaxClassifier.ClassifyTypeSyntax(NameSyntax name, SemanticModel semanticModel, ArrayBuilder`1 result, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.CSharp.Classification.Classifiers.NameSyntaxClassifier.AddClassifications(Workspace workspace, SyntaxNode syntax, SemanticModel semanticModel, ArrayBuilder`1 result, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.Classification.AbstractSyntaxClassificationService.Worker.ClassifyNode(SyntaxNode syntax)
   at Microsoft.CodeAnalysis.Classification.AbstractSyntaxClassificationService.Worker.ProcessNodes()
   at Microsoft.CodeAnalysis.Classification.AbstractSyntaxClassificationService.Worker.Classify(Workspace workspace, SemanticModel semanticModel, TextSpan textSpan, ArrayBuilder`1 list, Func`2 getNodeClassifiers, Func`2 getTokenClassifiers, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.Classification.AbstractSyntaxClassificationService.AddSemanticClassifications(SemanticModel semanticModel, TextSpan textSpan, Workspace workspace, Func`2 getNodeClassifiers, Func`2 getTokenClassifiers, ArrayBuilder`1 result, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.Classification.Classifier.GetClassifiedSpans(SemanticModel semanticModel, TextSpan textSpan, Workspace workspace, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.Classification.Classifier.GetClassifiedSpansAsync(Document document, TextSpan textSpan, CancellationToken cancellationToken)
   at Replay.Services.SyntaxHighlighter.HighlightAsync(ReplSubmission submission)
   at Replay.Services.ReplServices.HighlightAsync(Guid lineId, String code)
   at Replay.UI.AvalonSyntaxHighlightTransformer.ColorizeLineAsync(DocumentLine line, DocumentContext context, IList`1 elements)
   at ICSharpCode.AvalonEdit.Rendering.AsyncDocumentColorizingTransformer.ColorizeAsync(ITextRunConstructionContext context, IList`1 elements)
   at ICSharpCode.AvalonEdit.Rendering.AsyncColorizingTransformer.Transform(ITextRunConstructionContext context, IList`1 elements)
   at System.Threading.Tasks.Task.<>c.<ThrowAsync>b__139_0(Object state)
   at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
   at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)
   at System.Windows.Threading.DispatcherOperation.InvokeImpl()
   at MS.Internal.CulturePreservingExecutionContext.CallbackWrapper(Object obj)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location where exception was thrown ---
   at MS.Internal.CulturePreservingExecutionContext.Run(CulturePreservingExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Windows.Threading.DispatcherOperation.Invoke()
   at System.Windows.Threading.Dispatcher.ProcessQueue()
   at System.Windows.Threading.Dispatcher.WndProcHook(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
   at MS.Win32.HwndWrapper.WndProc(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
   at MS.Win32.HwndSubclass.DispatcherCallbackOperation(Object o)
   at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
   at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)
   at System.Windows.Threading.Dispatcher.LegacyInvokeImpl(DispatcherPriority priority, TimeSpan timeout, Delegate method, Object args, Int32 numArgs)
   at MS.Win32.HwndSubclass.SubclassWndProc(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam)
   at MS.Win32.UnsafeNativeMethods.DispatchMessage(MSG& msg)
   at System.Windows.Threading.Dispatcher.PushFrameImpl(DispatcherFrame frame)
   at System.Windows.Threading.Dispatcher.PushFrame(DispatcherFrame frame)
   at System.Windows.Threading.Dispatcher.Run()
   at System.Windows.Application.RunDispatcher(Object ignore)
   at System.Windows.Application.RunInternal(Window window)
   at System.Windows.Application.Run()
   at Replay.App.Main()
```

Exceptions like this shouldn't crash the application. Instead, just abort the current classification call and allow subsequent ones to complete.